### PR TITLE
BREAKING CHANGE: Require Node 8+

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2
 
 jobs:
-  node-latest:
+  node@latest:
     docker:
       - image: circleci/node:latest
 
@@ -21,7 +21,7 @@ jobs:
           command: npm run lint
           when: always
 
-  node-10:
+  node@10:
     docker:
       - image: circleci/node:10
 
@@ -36,7 +36,7 @@ jobs:
           name: Run tests
           command: npm test
 
-  node-8:
+  node@8:
     docker:
       - image: circleci/node:8
 
@@ -56,6 +56,6 @@ workflows:
 
   on-commit:
     jobs:
-      - node-latest
-      - node-10
-      - node-8
+      - node@latest
+      - node@10
+      - node@8

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,7 @@
 version: 2
+
 jobs:
-  build@node-latest:
+  node-latest:
     docker:
       - image: circleci/node:latest
 
@@ -20,7 +21,7 @@ jobs:
           command: npm run lint
           when: always
 
-  build@node-10:
+  node-10:
     docker:
       - image: circleci/node:8
 
@@ -35,7 +36,7 @@ jobs:
           name: Run tests
           command: npm test
 
-  build@node-8:
+  node-8:
     docker:
       - image: circleci/node:8
 
@@ -49,3 +50,12 @@ jobs:
       - run:
           name: Run tests
           command: npm test
+
+workflows:
+  version: 2
+
+  on-commit:
+    jobs:
+      - node-latest
+      - node-10
+      - node-8

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,8 +1,8 @@
 version: 2
 jobs:
-  build:
+  build@node-latest:
     docker:
-      - image: circleci/node:6
+      - image: circleci/node:latest
 
     steps:
       - checkout
@@ -19,3 +19,33 @@ jobs:
           name: Check lint
           command: npm run lint
           when: always
+
+  build@node-10:
+    docker:
+      - image: circleci/node:8
+
+    steps:
+      - checkout
+
+      - run:
+          name: Install dependencies
+          command: npm install
+
+      - run:
+          name: Run tests
+          command: npm test
+
+  build@node-8:
+    docker:
+      - image: circleci/node:8
+
+    steps:
+      - checkout
+
+      - run:
+          name: Install dependencies
+          command: npm install
+
+      - run:
+          name: Run tests
+          command: npm test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,7 +23,7 @@ jobs:
 
   node-10:
     docker:
-      - image: circleci/node:8
+      - image: circleci/node:10
 
     steps:
       - checkout

--- a/package.json
+++ b/package.json
@@ -80,6 +80,9 @@
     "build:umd:min": "cross-env BABEL_ENV=commonjs NODE_ENV=prod webpack src/main.js dist/sazerac.min.js",
     "build:commonjs": "cross-env BABEL_ENV=commonjs babel src --out-dir lib"
   },
+  "engine": {
+    "node": ">= 8"
+  },
   "jest": {
     "testRegex": "/test/e2e/spec/.*",
     "moduleNameMapper": {


### PR DESCRIPTION
Node 6 reaches EOL this week. Upgrading allows us to take advantage of newer syntax, and eliminates the overhead of keeping CI and tests running in a very old version of node (which does not create value).

I'm running into issues now with checking in the lockfile and using `npm ci` on Node 6, so it seems like as good a time to do this as any.