### PR TITLE
Improve typesafety

### DIFF
--- a/types/main.d.ts
+++ b/types/main.d.ts
@@ -1,15 +1,25 @@
-export class TestCase {
-  expect(returnValue: any): this
-  describe(message: string): this
-  should(message: string): this
+export class TestCase<Fn extends (...args: any[]) => any> {
+  expect(returnValue: ReturnType<Fn>): this;
+  describe(message: string): this;
+  should(message: string): this;
   assert(
     message: string,
-    assertFunction: (actualReturnValue: any) => void
-  ): this
+    assertFunction: (actualReturnValue: ReturnType<Fn>) => void
+  ): this;
 }
 
-export interface Given extends TestCase {}
+export interface Given<Fn extends (...args: any[]) => any>
+  extends TestCase<Fn> {}
 
-export function test(testFn: Function, definerFn: Function): void
-export function given(...args: any[]): Given
-export function forCases(testCases: Given[]): TestCase
+export function test<Fn extends (...args: any[]) => any>(
+  testFn: Fn,
+  definerFn: () => void
+): void;
+
+export function given<Fn extends (...args: any[]) => any>(
+  ...args: Parameters<Fn>
+): Given<Fn>;
+
+export function forCases<Fn extends (...args: any[]) => any>(
+  testCases: Given<Fn>[]
+): TestCase<Fn>;


### PR DESCRIPTION
This provides better typesafety when used with TypeScript:
```typescript
// Everything's inferred
test(Object.keys, (): void => {
  given({ test: true }).expect(["test"]);
});

test(
  Object.keys,
  // Error: no args are provided to definerFn
  (somethingCool): void => {
    given({ test: true }).expect(["test"]);
  }
);

test<(a: number, b: number) => number>(
  // Error, the function doesn't match the type
  Object.keys,
  (): void => {
    given(1, 2).expect(3);
  }
);

test(Object.keys, (): void => {
  given<(o: object) => string[]>(
    // Error: wrong argument type
    1
  ).expect(
    // Error: wrong return value type type
    3
  );
});
```

This doesn't affect JS users in the slightest but for some TS users it is a breaking change as the generic types are required. They will be infered in function calls but those, who use the exported interfaces, will have to explicitly fill it in. I don't see this as a problem, in the end, if someone uses the types explicitly, they probably want typesafety anyway, but it would be possible to make them optional (and therefore worsen the typesafety) to avoid breaking changes.

Also the definerFn type now prohibits arguments (no warning was given before) but there were never any passed so probably not something anybody would care about.